### PR TITLE
Add FastBoot support

### DIFF
--- a/addon/initializers/browser-update.js
+++ b/addon/initializers/browser-update.js
@@ -1,9 +1,11 @@
 import browserUpdate from 'browser-update';
 
 export function initialize(application) {
-  if (application.hasRegistration('config:environment')) {
-    const config = application.resolveRegistration('config:environment');
-    browserUpdate(config['browserUpdate']);
+  if(typeof FastBoot === 'undefined') {
+    if (application.hasRegistration('config:environment')) {
+      const config = application.resolveRegistration('config:environment');
+      browserUpdate(config['browserUpdate']);
+    }
   }
 }
 


### PR DESCRIPTION
This prevents browserUpdate from running in FastBoot since it uses browser APIs.